### PR TITLE
Switched to process based parallelism

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,16 +29,13 @@ jobs:
       - name: Install RDKit with conda
         run: conda install -y rdkit
 
-      - name: Install package and pytest
+      - name: Install package, ASE dependencies, and pytest
         run: |
           python -m pip install --upgrade pip
-          pip install -e . pytest
+          pip install -e ".[ase]" pytest
 
       - name: Run default pytest suite
         run: pytest
-
-      - name: Install ASE
-        run: pip install ase
 
       - name: Run ASE-marked tests
         run: |

--- a/docs/modules/ff_optimizer.md
+++ b/docs/modules/ff_optimizer.md
@@ -65,6 +65,6 @@ from racerts.optimizer import ASEOptimizer
 
 optimizer = ASEOptimizer(
     calculator=LennardJones,
-    num_threads=4,
+    num_workers=4,
 )
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ include = ["racerts*"]
 [project.optional-dependencies]
 ase = [
     "ase>=3.22.0",
+    "threadpoolctl>=3.0.0",
 ]
 dev = [
     "black>=21.12b0",

--- a/src/racerts/optimizer/ase.py
+++ b/src/racerts/optimizer/ase.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
-import multiprocessing
-import os
 from collections.abc import Callable as ABCCallable
-from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
-from copy import deepcopy
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from functools import wraps
 from importlib import import_module
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type
 
 from rdkit import Chem
 from rdkit.Geometry import Point3D
 
 from .ff_optimizer import BaseOptimizer
+from .parallel import (
+    OptimizationConfig,
+    OptimizationTask,
+    run_optimization,
+    run_optimizations_in_processes,
+)
 
 if TYPE_CHECKING:
     from ase import Atoms as ASEAtoms
@@ -126,126 +128,6 @@ def write_ase_positions_to_rdkit(atoms: ASEAtoms, mol: Chem.Mol, conf_id: int) -
         )
 
 
-# Process-based parallel optimization.
-#
-# Each conformer is relaxed in its own spawned, single-thread-pinned worker process (many
-# ASE calculators are not thread-safe, so processes are used instead of threads). Atoms
-# objects carrying only geometry and constraints are shipped keyed by conformer id, and
-# results are echoed back with their id so the parent can write the optimized positions
-# and energies onto the RDKit Mol.
-
-
-@dataclass(frozen=True)
-class _RunConfig:
-    """
-    Optimizer settings shared by every conformer (pickled once per worker).
-    """
-
-    optimizer_cls: Type
-    optimizer_kwargs: Dict[str, Any] = field(default_factory=dict)
-    fmax: float = 0.05
-    max_steps: int = 100
-
-
-# Per-worker calculator/config, set once in the pool initializer and reused across tasks.
-_WORKER_CALC: Any = None
-_WORKER_CONFIG: Optional[_RunConfig] = None
-# Holds the threadpoolctl controller so the single-thread limit lives for the worker's
-# whole life (and is never restored).
-_PIN: Any = None
-
-
-def pin_to_single_thread() -> None:
-    """
-    Pin the calling process to a single native thread across all thread pools.
-
-    Caps OpenMP (libgomp) and BLAS/LAPACK (OpenBLAS/MKL) to one thread via threadpoolctl.
-    This is required per dedicated worker: xTB/GFN-FF anti-scale with thread count on
-    small systems, so N concurrent workers must not each spawn N x (OpenMP + BLAS)
-    threads and thrash the node.
-    """
-    global _PIN
-    from threadpoolctl import threadpool_limits
-
-    _PIN = threadpool_limits(limits=1)
-
-
-def _init_worker(calculator_payload: Any, is_factory: bool, config: _RunConfig) -> None:
-    """
-    Pool initializer: pin to one thread, then build this worker's calculator.
-
-    The calculator_payload is either a factory (called here) or a deepcopied calculator
-    instance (delivered, and unpickled, per worker via initargs), giving each worker its
-    own independent calculator.
-
-    Args:
-        calculator_payload (Any): A calculator factory or a deepcopied calculator
-            instance.
-        is_factory (bool): Whether calculator_payload should be called to build the
-            calculator.
-        config (_RunConfig): The shared optimizer settings.
-    """
-    global _WORKER_CALC, _WORKER_CONFIG
-    pin_to_single_thread()
-    if is_factory:
-        calculator = calculator_payload()
-        if calculator is None:
-            raise ValueError("`calculator` callable returned None.")
-        _WORKER_CALC = calculator
-    else:
-        _WORKER_CALC = calculator_payload
-    _WORKER_CONFIG = config
-
-
-def _optimize_one(
-    calc: Any, config: _RunConfig, conf_id: int, atoms: ASEAtoms
-) -> Tuple[int, Any, float, bool]:
-    """
-    Relax one structure and return (conf_id, positions, energy_eV, converged).
-    """
-    atoms = atoms.copy()  # never mutate the caller's shipped geometry
-    atoms.calc = calc
-    optimizer = config.optimizer_cls(atoms, **config.optimizer_kwargs)
-    converged = optimizer.run(fmax=config.fmax, steps=config.max_steps)
-    return (
-        conf_id,
-        atoms.get_positions(),
-        float(atoms.get_potential_energy()),
-        bool(converged),
-    )
-
-
-def _optimize_task(task: Tuple[int, ASEAtoms]) -> Tuple[int, Any, float, bool]:
-    """
-    Picklable pool entry point: relax with this worker's resident calculator.
-    """
-    conf_id, atoms = task
-    return _optimize_one(_WORKER_CALC, _WORKER_CONFIG, conf_id, atoms)
-
-
-def _resolve_workers(n_workers: Optional[int], n_tasks: int) -> int:
-    """
-    Clamp the requested worker count to the cores available and tasks on hand.
-
-    A value of None or <= 0 auto-sizes to the number of CPUs this process may run on (the
-    SLURM allocation, via sched_getaffinity when present), capped at one worker per task.
-
-    Args:
-        n_workers (int): The requested worker count, or None to auto-size.
-        n_tasks (int): The number of tasks to distribute.
-
-    Returns:
-        int: The resolved worker count.
-    """
-    if hasattr(os, "sched_getaffinity"):
-        available = len(os.sched_getaffinity(0))
-    else:
-        available = os.cpu_count() or 1
-    if n_workers is None or n_workers <= 0:
-        n_workers = available
-    return max(1, min(n_workers, n_tasks))
-
-
 class ASEOptimizer(BaseOptimizer):
     @requires_dependency([Import(module="ase.optimize", item="BFGS")], globals())
     def __init__(
@@ -258,7 +140,6 @@ class ASEOptimizer(BaseOptimizer):
         verbose: bool = False,
         conf_id_ref: int = -1,
         force_constant: float = 1e6,
-        num_threads: int = 1,
         num_workers: Optional[int] = 1,
     ):
         if calculator is None:
@@ -278,7 +159,6 @@ class ASEOptimizer(BaseOptimizer):
         self.verbose = verbose
         self.conf_id_ref = conf_id_ref
         self.force_constant = force_constant
-        self.num_threads = num_threads
         self.num_workers = num_workers
 
         if "logfile" not in self.optimizer_kwargs and not self.verbose:
@@ -292,19 +172,6 @@ class ASEOptimizer(BaseOptimizer):
             and not hasattr(calculator, "get_property")
         )
 
-    def _use_processes(self) -> bool:
-        """
-        Whether to run the process pool rather than serially.
-
-        num_workers of None means auto-size to all available cores (resolved by
-        _resolve_workers), matching the convention of catmlp's relax_conformers; a
-        value greater than 1 requests that many workers; 0 or 1 runs serially.
-
-        Returns:
-            bool: True if the process pool should be used.
-        """
-        return self.num_workers is None or self.num_workers > 1
-
     def _get_calculator(self):
         if self._calculator_is_factory:
             calculator = self.calculator()
@@ -312,95 +179,7 @@ class ASEOptimizer(BaseOptimizer):
                 raise ValueError("`calculator` callable returned None.")
             return calculator
 
-        if self.num_threads > 1:
-            try:
-                return deepcopy(self.calculator)
-            except Exception as exc:
-                raise RuntimeError(
-                    "Unable to deepcopy the ASE calculator for threaded execution. "
-                    "Use a callable `calculator` or set `num_threads=1`."
-                ) from exc
-
         return self.calculator
-
-    def _calculator_payload(self) -> Tuple[Any, bool]:
-        """
-        Return (payload, is_factory) to ship to worker processes.
-
-        A factory is shipped as-is (each worker calls it); a calculator instance is
-        deepcopied so that each worker unpickles its own independent copy across the
-        spawn boundary.
-
-        Returns:
-            tuple: The calculator payload and a flag for whether it is a factory.
-        """
-        if self._calculator_is_factory:
-            return self.calculator, True
-        try:
-            return deepcopy(self.calculator), False
-        except Exception as exc:
-            raise RuntimeError(
-                "Unable to deepcopy the ASE calculator for process-parallel execution. "
-                "Pass a picklable `calculator` factory or set `num_workers=1`."
-            ) from exc
-
-    def _optimize_parallel(
-        self,
-        mol: Chem.Mol,
-        constraints: Optional[List[Any]],
-    ) -> int:
-        """
-        Relax every conformer across a spawned process pool and write results back.
-
-        Geometry (with constraints) is shipped per conformer; the parent writes the
-        optimized positions and energy onto mol. This matches the serial optimize
-        contract.
-
-        Args:
-            mol (Chem.Mol): The molecule whose conformers are optimized in place.
-            constraints (list): The ASE constraints applied to every conformer.
-
-        Returns:
-            int: The total number of conformers that failed to converge.
-        """
-        tasks: List[Tuple[int, ASEAtoms]] = []
-        for conformer in mol.GetConformers():
-            conf_id = conformer.GetId()
-            atoms = rdkit_conformer_to_ase_atoms(mol, conf_id=conf_id)
-            if constraints:
-                atoms.set_constraint(constraints)
-            tasks.append((conf_id, atoms))
-
-        if not tasks:
-            return 0
-
-        config = _RunConfig(
-            optimizer_cls=self.optimizer_cls,
-            optimizer_kwargs=dict(self.optimizer_kwargs),
-            fmax=self.fmax,
-            max_steps=self.max_steps,
-        )
-        payload, is_factory = self._calculator_payload()
-        workers = _resolve_workers(self.num_workers, len(tasks))
-        ctx = multiprocessing.get_context("spawn")
-        with ProcessPoolExecutor(
-            max_workers=workers,
-            mp_context=ctx,
-            initializer=_init_worker,
-            initargs=(payload, is_factory, config),
-        ) as pool:
-            results = list(pool.map(_optimize_task, tasks))
-
-        failures = 0
-        for conf_id, positions, energy_ev, converged in results:
-            conf = mol.GetConformer(conf_id)
-            for idx, xyz in enumerate(positions):
-                conf.SetAtomPosition(
-                    idx, Point3D(float(xyz[0]), float(xyz[1]), float(xyz[2]))
-                )
-            conf.SetDoubleProp("energy", energy_ev * EV_TO_KCAL_MOL)
-            failures += 0 if converged else 1
-        return failures
 
     def optimize(
         self,
@@ -408,31 +187,59 @@ class ASEOptimizer(BaseOptimizer):
         constraints: Optional[List[Any]] = None,
         conf_id: Optional[int] = None,
     ) -> int:
-        if conf_id is None:
-            if self._use_processes():
-                return self._optimize_parallel(mol=mol, constraints=constraints)
-            return sum(
-                self.optimize(
-                    mol=mol,
-                    constraints=constraints,
-                    conf_id=conformer.GetId(),
-                )
-                for conformer in mol.GetConformers()
+        """Optimize one conformer or the full ensemble in place.
+
+        Full-ensemble calls use spawned processes when ``num_workers`` is ``None``
+        or greater than one; otherwise conformers are optimized serially. A call
+        with ``conf_id`` always optimizes that conformer serially.
+        """
+        conf_ids = (
+            [conf_id]
+            if conf_id is not None
+            else [conformer.GetId() for conformer in mol.GetConformers()]
+        )
+        tasks: List[OptimizationTask] = []
+        for task_conf_id in conf_ids:
+            atoms = rdkit_conformer_to_ase_atoms(mol, conf_id=task_conf_id)
+            if constraints:
+                atoms.set_constraint(constraints)
+            tasks.append((task_conf_id, atoms))
+
+        if not tasks:
+            return 0
+
+        config = OptimizationConfig(
+            optimizer_cls=self.optimizer_cls,
+            optimizer_kwargs=dict(self.optimizer_kwargs),
+            fmax=self.fmax,
+            max_steps=self.max_steps,
+        )
+        use_processes = conf_id is None and (
+            self.num_workers is None or self.num_workers > 1
+        )
+        if use_processes:
+            results = run_optimizations_in_processes(
+                tasks=tasks,
+                calculator=self.calculator,
+                calculator_is_factory=self._calculator_is_factory,
+                config=config,
+                num_workers=self.num_workers,
             )
+        else:
+            results = [
+                run_optimization(self._get_calculator(), config, task) for task in tasks
+            ]
 
-        atoms = rdkit_conformer_to_ase_atoms(mol, conf_id=conf_id)
-        if constraints:
-            atoms.set_constraint(constraints)
-
-        atoms.calc = self._get_calculator()
-        ase_optimizer = self.optimizer_cls(atoms, **self.optimizer_kwargs)
-        converged = ase_optimizer.run(fmax=self.fmax, steps=self.max_steps)
-
-        write_ase_positions_to_rdkit(atoms, mol=mol, conf_id=conf_id)
-        energy_kcal_mol = atoms.get_potential_energy() * EV_TO_KCAL_MOL
-        mol.GetConformer(conf_id).SetDoubleProp("energy", energy_kcal_mol)
-
-        return 0 if bool(converged) else 1
+        failures = 0
+        for result_conf_id, positions, energy_ev, converged in results:
+            conf = mol.GetConformer(result_conf_id)
+            for idx, xyz in enumerate(positions):
+                conf.SetAtomPosition(
+                    idx, Point3D(float(xyz[0]), float(xyz[1]), float(xyz[2]))
+                )
+            conf.SetDoubleProp("energy", energy_ev * EV_TO_KCAL_MOL)
+            failures += 0 if converged else 1
+        return failures
 
     @requires_dependency([Import(module="ase.constraints", item="FixAtoms")], globals())
     def tune_ts_conformers(
@@ -446,61 +253,25 @@ class ASEOptimizer(BaseOptimizer):
         if self.conf_id_ref == -1:
             self.conf_id_ref = reference.GetConformer().GetId()
 
-        def _optimize(conf_id: int) -> int:
-            self.align_mols(
-                mol=mol,
-                reference=reference,
-                align_indices=align_indices,
-                conf_id=conf_id,
-            )
-
-            constraints = None
-            if align_indices:
-                constraints = [FixAtoms(indices=align_indices)]
-
-            local_fail = self.optimize(
-                mol=mol,
-                constraints=constraints,
-                conf_id=conf_id,
-            )
-
-            self.align_mols(
-                mol=mol,
-                reference=reference,
-                align_indices=align_indices,
-                conf_id=conf_id,
-            )
-
-            return local_fail
-
         conformer_ids = [conf.GetId() for conf in mol.GetConformers()]
+        for conf_id in conformer_ids:
+            self.align_mols(
+                mol=mol,
+                reference=reference,
+                align_indices=align_indices,
+                conf_id=conf_id,
+            )
 
-        if self._use_processes():
-            # Process-parallel path overrides the thread path. Alignment is cheap RDKit
-            # work and each conformer is independent, so align all in this process, relax
-            # them across the pool in one shot, then re-align. This is equivalent to the
-            # per-conformer align, optimize, align loop below.
-            constraints = [FixAtoms(indices=align_indices)] if align_indices else None
-            for conf_id in conformer_ids:
-                self.align_mols(
-                    mol=mol,
-                    reference=reference,
-                    align_indices=align_indices,
-                    conf_id=conf_id,
-                )
-            ase_failures = self.optimize(mol=mol, constraints=constraints)
-            for conf_id in conformer_ids:
-                self.align_mols(
-                    mol=mol,
-                    reference=reference,
-                    align_indices=align_indices,
-                    conf_id=conf_id,
-                )
-        elif self.num_threads > 1:
-            with ThreadPoolExecutor(max_workers=self.num_threads) as pool:
-                ase_failures = sum(pool.map(_optimize, conformer_ids))
-        else:
-            ase_failures = sum(_optimize(conf_id) for conf_id in conformer_ids)
+        constraints = [FixAtoms(indices=align_indices)] if align_indices else None
+        ase_failures = self.optimize(mol=mol, constraints=constraints)
+
+        for conf_id in conformer_ids:
+            self.align_mols(
+                mol=mol,
+                reference=reference,
+                align_indices=align_indices,
+                conf_id=conf_id,
+            )
 
         if self.verbose:
             print(f"ASE failures: {ase_failures}")

--- a/src/racerts/optimizer/ase.py
+++ b/src/racerts/optimizer/ase.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import multiprocessing
+import os
 from collections.abc import Callable as ABCCallable
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, ThreadPoolExecutor
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import wraps
 from importlib import import_module
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Type
 
 from rdkit import Chem
 from rdkit.Geometry import Point3D
@@ -54,11 +56,64 @@ def requires_dependency(imports: List[Import], scope: Dict[str, Any]):
 EV_TO_KCAL_MOL = 23.06054783061903
 
 
+def infer_charge_and_multiplicity(mol: Chem.Mol) -> Dict[str, int]:
+    """
+    Infer the total formal charge and spin multiplicity of an RDKit molecule.
+
+    Args:
+        mol (Chem.Mol): The molecule to inspect.
+
+    Returns:
+        dict: A dict with charge (sum of per-atom formal charges) and multiplicity
+            (2S + 1 = n_radical_electrons + 1).
+    """
+    charge = sum(a.GetFormalCharge() for a in mol.GetAtoms())
+    multiplicity = 1 + sum(a.GetNumRadicalElectrons() for a in mol.GetAtoms())
+    return {"charge": charge, "multiplicity": multiplicity}
+
+
 @requires_dependency([Import(module="ase", item="Atoms")], globals())
-def rdkit_conformer_to_ase_atoms(mol: Chem.Mol, conf_id: int) -> ASEAtoms:
+def rdkit_conformer_to_ase_atoms(
+    mol: Chem.Mol,
+    conf_id: int,
+    multiplicity: Optional[int] = None,
+    charge: Optional[int] = None,
+) -> ASEAtoms:
+    """
+    Convert one conformer of an RDKit Mol to an ASE Atoms object.
+
+    Charge and spin multiplicity are stored on atoms.info (charge, spin and multiplicity,
+    where spin is the multiplicity expected by UMA models) so that downstream calculators
+    treat charged/radical species correctly. When either is None it is inferred from mol
+    via infer_charge_and_multiplicity.
+
+    Args:
+        mol (Chem.Mol): The molecule with at least one embedded conformer.
+        conf_id (int): The conformer to read.
+        multiplicity (int): The spin multiplicity. Inferred from mol when None.
+        charge (int): The total formal charge. Inferred from mol when None.
+
+    Returns:
+        ASEAtoms: The conformer geometry, with charge and spin set on atoms.info.
+    """
+    if multiplicity is None or charge is None:
+        inferred = infer_charge_and_multiplicity(mol)
+        if multiplicity is None:
+            multiplicity = inferred["multiplicity"]
+        if charge is None:
+            charge = inferred["charge"]
+
     conf = mol.GetConformer(conf_id)
     symbols = [atom.GetSymbol() for atom in mol.GetAtoms()]
-    return Atoms(symbols=symbols, positions=conf.GetPositions())
+    atoms = Atoms(symbols=symbols, positions=conf.GetPositions())
+    atoms.info.update(
+        {
+            "charge": int(charge),
+            "spin": int(multiplicity),  # for uma models
+            "multiplicity": int(multiplicity),
+        }
+    )
+    return atoms
 
 
 def write_ase_positions_to_rdkit(atoms: ASEAtoms, mol: Chem.Mol, conf_id: int) -> None:
@@ -69,6 +124,126 @@ def write_ase_positions_to_rdkit(atoms: ASEAtoms, mol: Chem.Mol, conf_id: int) -
             idx,
             Point3D(float(xyz[0]), float(xyz[1]), float(xyz[2])),
         )
+
+
+# Process-based parallel optimization.
+#
+# Each conformer is relaxed in its own spawned, single-thread-pinned worker process (many
+# ASE calculators are not thread-safe, so processes are used instead of threads). Atoms
+# objects carrying only geometry and constraints are shipped keyed by conformer id, and
+# results are echoed back with their id so the parent can write the optimized positions
+# and energies onto the RDKit Mol.
+
+
+@dataclass(frozen=True)
+class _RunConfig:
+    """
+    Optimizer settings shared by every conformer (pickled once per worker).
+    """
+
+    optimizer_cls: Type
+    optimizer_kwargs: Dict[str, Any] = field(default_factory=dict)
+    fmax: float = 0.05
+    max_steps: int = 100
+
+
+# Per-worker calculator/config, set once in the pool initializer and reused across tasks.
+_WORKER_CALC: Any = None
+_WORKER_CONFIG: Optional[_RunConfig] = None
+# Holds the threadpoolctl controller so the single-thread limit lives for the worker's
+# whole life (and is never restored).
+_PIN: Any = None
+
+
+def pin_to_single_thread() -> None:
+    """
+    Pin the calling process to a single native thread across all thread pools.
+
+    Caps OpenMP (libgomp) and BLAS/LAPACK (OpenBLAS/MKL) to one thread via threadpoolctl.
+    This is required per dedicated worker: xTB/GFN-FF anti-scale with thread count on
+    small systems, so N concurrent workers must not each spawn N x (OpenMP + BLAS)
+    threads and thrash the node.
+    """
+    global _PIN
+    from threadpoolctl import threadpool_limits
+
+    _PIN = threadpool_limits(limits=1)
+
+
+def _init_worker(calculator_payload: Any, is_factory: bool, config: _RunConfig) -> None:
+    """
+    Pool initializer: pin to one thread, then build this worker's calculator.
+
+    The calculator_payload is either a factory (called here) or a deepcopied calculator
+    instance (delivered, and unpickled, per worker via initargs), giving each worker its
+    own independent calculator.
+
+    Args:
+        calculator_payload (Any): A calculator factory or a deepcopied calculator
+            instance.
+        is_factory (bool): Whether calculator_payload should be called to build the
+            calculator.
+        config (_RunConfig): The shared optimizer settings.
+    """
+    global _WORKER_CALC, _WORKER_CONFIG
+    pin_to_single_thread()
+    if is_factory:
+        calculator = calculator_payload()
+        if calculator is None:
+            raise ValueError("`calculator` callable returned None.")
+        _WORKER_CALC = calculator
+    else:
+        _WORKER_CALC = calculator_payload
+    _WORKER_CONFIG = config
+
+
+def _optimize_one(
+    calc: Any, config: _RunConfig, conf_id: int, atoms: ASEAtoms
+) -> Tuple[int, Any, float, bool]:
+    """
+    Relax one structure and return (conf_id, positions, energy_eV, converged).
+    """
+    atoms = atoms.copy()  # never mutate the caller's shipped geometry
+    atoms.calc = calc
+    optimizer = config.optimizer_cls(atoms, **config.optimizer_kwargs)
+    converged = optimizer.run(fmax=config.fmax, steps=config.max_steps)
+    return (
+        conf_id,
+        atoms.get_positions(),
+        float(atoms.get_potential_energy()),
+        bool(converged),
+    )
+
+
+def _optimize_task(task: Tuple[int, ASEAtoms]) -> Tuple[int, Any, float, bool]:
+    """
+    Picklable pool entry point: relax with this worker's resident calculator.
+    """
+    conf_id, atoms = task
+    return _optimize_one(_WORKER_CALC, _WORKER_CONFIG, conf_id, atoms)
+
+
+def _resolve_workers(n_workers: Optional[int], n_tasks: int) -> int:
+    """
+    Clamp the requested worker count to the cores available and tasks on hand.
+
+    A value of None or <= 0 auto-sizes to the number of CPUs this process may run on (the
+    SLURM allocation, via sched_getaffinity when present), capped at one worker per task.
+
+    Args:
+        n_workers (int): The requested worker count, or None to auto-size.
+        n_tasks (int): The number of tasks to distribute.
+
+    Returns:
+        int: The resolved worker count.
+    """
+    if hasattr(os, "sched_getaffinity"):
+        available = len(os.sched_getaffinity(0))
+    else:
+        available = os.cpu_count() or 1
+    if n_workers is None or n_workers <= 0:
+        n_workers = available
+    return max(1, min(n_workers, n_tasks))
 
 
 class ASEOptimizer(BaseOptimizer):
@@ -84,6 +259,7 @@ class ASEOptimizer(BaseOptimizer):
         conf_id_ref: int = -1,
         force_constant: float = 1e6,
         num_threads: int = 1,
+        num_workers: Optional[int] = 1,
     ):
         if calculator is None:
             raise ValueError("`calculator` must be provided.")
@@ -103,6 +279,7 @@ class ASEOptimizer(BaseOptimizer):
         self.conf_id_ref = conf_id_ref
         self.force_constant = force_constant
         self.num_threads = num_threads
+        self.num_workers = num_workers
 
         if "logfile" not in self.optimizer_kwargs and not self.verbose:
             self.optimizer_kwargs["logfile"] = None
@@ -114,6 +291,19 @@ class ASEOptimizer(BaseOptimizer):
             isinstance(calculator, ABCCallable)
             and not hasattr(calculator, "get_property")
         )
+
+    def _use_processes(self) -> bool:
+        """
+        Whether to run the process pool rather than serially.
+
+        num_workers of None means auto-size to all available cores (resolved by
+        _resolve_workers), matching the convention of catmlp's relax_conformers; a
+        value greater than 1 requests that many workers; 0 or 1 runs serially.
+
+        Returns:
+            bool: True if the process pool should be used.
+        """
+        return self.num_workers is None or self.num_workers > 1
 
     def _get_calculator(self):
         if self._calculator_is_factory:
@@ -133,6 +323,85 @@ class ASEOptimizer(BaseOptimizer):
 
         return self.calculator
 
+    def _calculator_payload(self) -> Tuple[Any, bool]:
+        """
+        Return (payload, is_factory) to ship to worker processes.
+
+        A factory is shipped as-is (each worker calls it); a calculator instance is
+        deepcopied so that each worker unpickles its own independent copy across the
+        spawn boundary.
+
+        Returns:
+            tuple: The calculator payload and a flag for whether it is a factory.
+        """
+        if self._calculator_is_factory:
+            return self.calculator, True
+        try:
+            return deepcopy(self.calculator), False
+        except Exception as exc:
+            raise RuntimeError(
+                "Unable to deepcopy the ASE calculator for process-parallel execution. "
+                "Pass a picklable `calculator` factory or set `num_workers=1`."
+            ) from exc
+
+    def _optimize_parallel(
+        self,
+        mol: Chem.Mol,
+        constraints: Optional[List[Any]],
+    ) -> int:
+        """
+        Relax every conformer across a spawned process pool and write results back.
+
+        Geometry (with constraints) is shipped per conformer; the parent writes the
+        optimized positions and energy onto mol. This matches the serial optimize
+        contract.
+
+        Args:
+            mol (Chem.Mol): The molecule whose conformers are optimized in place.
+            constraints (list): The ASE constraints applied to every conformer.
+
+        Returns:
+            int: The total number of conformers that failed to converge.
+        """
+        tasks: List[Tuple[int, ASEAtoms]] = []
+        for conformer in mol.GetConformers():
+            conf_id = conformer.GetId()
+            atoms = rdkit_conformer_to_ase_atoms(mol, conf_id=conf_id)
+            if constraints:
+                atoms.set_constraint(constraints)
+            tasks.append((conf_id, atoms))
+
+        if not tasks:
+            return 0
+
+        config = _RunConfig(
+            optimizer_cls=self.optimizer_cls,
+            optimizer_kwargs=dict(self.optimizer_kwargs),
+            fmax=self.fmax,
+            max_steps=self.max_steps,
+        )
+        payload, is_factory = self._calculator_payload()
+        workers = _resolve_workers(self.num_workers, len(tasks))
+        ctx = multiprocessing.get_context("spawn")
+        with ProcessPoolExecutor(
+            max_workers=workers,
+            mp_context=ctx,
+            initializer=_init_worker,
+            initargs=(payload, is_factory, config),
+        ) as pool:
+            results = list(pool.map(_optimize_task, tasks))
+
+        failures = 0
+        for conf_id, positions, energy_ev, converged in results:
+            conf = mol.GetConformer(conf_id)
+            for idx, xyz in enumerate(positions):
+                conf.SetAtomPosition(
+                    idx, Point3D(float(xyz[0]), float(xyz[1]), float(xyz[2]))
+                )
+            conf.SetDoubleProp("energy", energy_ev * EV_TO_KCAL_MOL)
+            failures += 0 if converged else 1
+        return failures
+
     def optimize(
         self,
         mol: Chem.Mol,
@@ -140,6 +409,8 @@ class ASEOptimizer(BaseOptimizer):
         conf_id: Optional[int] = None,
     ) -> int:
         if conf_id is None:
+            if self._use_processes():
+                return self._optimize_parallel(mol=mol, constraints=constraints)
             return sum(
                 self.optimize(
                     mol=mol,
@@ -204,7 +475,28 @@ class ASEOptimizer(BaseOptimizer):
 
         conformer_ids = [conf.GetId() for conf in mol.GetConformers()]
 
-        if self.num_threads > 1:
+        if self._use_processes():
+            # Process-parallel path overrides the thread path. Alignment is cheap RDKit
+            # work and each conformer is independent, so align all in this process, relax
+            # them across the pool in one shot, then re-align. This is equivalent to the
+            # per-conformer align, optimize, align loop below.
+            constraints = [FixAtoms(indices=align_indices)] if align_indices else None
+            for conf_id in conformer_ids:
+                self.align_mols(
+                    mol=mol,
+                    reference=reference,
+                    align_indices=align_indices,
+                    conf_id=conf_id,
+                )
+            ase_failures = self.optimize(mol=mol, constraints=constraints)
+            for conf_id in conformer_ids:
+                self.align_mols(
+                    mol=mol,
+                    reference=reference,
+                    align_indices=align_indices,
+                    conf_id=conf_id,
+                )
+        elif self.num_threads > 1:
             with ThreadPoolExecutor(max_workers=self.num_threads) as pool:
                 ase_failures = sum(pool.map(_optimize, conformer_ids))
         else:

--- a/src/racerts/optimizer/parallel.py
+++ b/src/racerts/optimizer/parallel.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import multiprocessing
+import os
+from concurrent.futures import ProcessPoolExecutor
+from copy import deepcopy
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ase import Atoms as ASEAtoms
+
+
+OptimizationTask = tuple[int, "ASEAtoms"]
+OptimizationResult = tuple[int, Any, float, bool]
+
+
+@dataclass(frozen=True)
+class OptimizationConfig:
+    """Optimizer settings shared by every conformer."""
+
+    optimizer_cls: type
+    optimizer_kwargs: dict[str, Any] = field(default_factory=dict)
+    fmax: float = 0.05
+    max_steps: int = 100
+
+
+# Per-worker calculator/config, set once in the pool initializer and reused across tasks.
+_WORKER_CALC: Any = None
+_WORKER_CONFIG: OptimizationConfig | None = None
+# Hold the threadpoolctl controller for the worker's lifetime so its limits are not
+# restored between tasks.
+_PIN: Any = None
+
+
+def pin_to_single_thread() -> None:
+    """Pin the calling process to one native thread across all thread pools."""
+    global _PIN
+    from threadpoolctl import threadpool_limits
+
+    _PIN = threadpool_limits(limits=1)
+
+
+def _init_worker(
+    calculator_payload: Any,
+    is_factory: bool,
+    config: OptimizationConfig,
+) -> None:
+    """Pin a pool worker and initialize its resident calculator and settings."""
+    global _WORKER_CALC, _WORKER_CONFIG
+    pin_to_single_thread()
+    if is_factory:
+        calculator = calculator_payload()
+        if calculator is None:
+            raise ValueError("`calculator` callable returned None.")
+        _WORKER_CALC = calculator
+    else:
+        _WORKER_CALC = calculator_payload
+    _WORKER_CONFIG = config
+
+
+def run_optimization(
+    calculator: Any,
+    config: OptimizationConfig,
+    task: OptimizationTask,
+) -> OptimizationResult:
+    """Relax one structure and return its id, positions, energy, and convergence."""
+    conf_id, atoms = task
+    atoms.calc = calculator
+    optimizer = config.optimizer_cls(atoms, **config.optimizer_kwargs)
+    converged = optimizer.run(fmax=config.fmax, steps=config.max_steps)
+    return (
+        conf_id,
+        atoms.get_positions(),
+        float(atoms.get_potential_energy()),
+        bool(converged),
+    )
+
+
+def _run_worker_optimization(task: OptimizationTask) -> OptimizationResult:
+    """Relax a structure with the current worker's resident calculator."""
+    if _WORKER_CONFIG is None:  # pragma: no cover - initializer contract
+        raise RuntimeError("Optimization worker was not initialized.")
+    return run_optimization(_WORKER_CALC, _WORKER_CONFIG, task)
+
+
+def _resolve_workers(n_workers: int | None, n_tasks: int) -> int:
+    """Clamp a requested worker count to the available CPUs and task count."""
+    if hasattr(os, "sched_getaffinity"):
+        available = len(os.sched_getaffinity(0))
+    else:
+        available = os.cpu_count() or 1
+    if n_workers is None or n_workers <= 0:
+        n_workers = available
+    return max(1, min(n_workers, n_tasks))
+
+
+def _calculator_payload(calculator: Any, is_factory: bool) -> tuple[Any, bool]:
+    """Prepare a calculator factory or independent instance for spawned workers."""
+    if is_factory:
+        return calculator, True
+    try:
+        return deepcopy(calculator), False
+    except Exception as exc:
+        raise RuntimeError(
+            "Unable to deepcopy the ASE calculator for process-parallel execution. "
+            "Pass a picklable `calculator` factory or set `num_workers=1`."
+        ) from exc
+
+
+def run_optimizations_in_processes(
+    tasks: list[OptimizationTask],
+    calculator: Any,
+    calculator_is_factory: bool,
+    config: OptimizationConfig,
+    num_workers: int | None,
+) -> list[OptimizationResult]:
+    """Relax conformers in spawned, single-thread-pinned worker processes."""
+    payload, is_factory = _calculator_payload(calculator, calculator_is_factory)
+    workers = _resolve_workers(num_workers, len(tasks))
+    ctx = multiprocessing.get_context("spawn")
+    with ProcessPoolExecutor(
+        max_workers=workers,
+        mp_context=ctx,
+        initializer=_init_worker,
+        initargs=(payload, is_factory, config),
+    ) as pool:
+        return list(pool.map(_run_worker_optimization, tasks))

--- a/src/racerts/pruner/pruner.py
+++ b/src/racerts/pruner/pruner.py
@@ -217,7 +217,11 @@ class RMSDPruner(BasePruner):
                 rot = self.calc_rotations(mol, id=int(j))
                 check = False
                 for i in range(3):
-                    f_rot = abs(ref_rotations[i] - rot[i]) / ref_rotations[i]
+                    difference = abs(ref_rotations[i] - rot[i])
+                    if ref_rotations[i] == 0.0:
+                        f_rot = 0.0 if rot[i] == 0.0 else np.inf
+                    else:
+                        f_rot = difference / ref_rotations[i]
                     if f_rot > rot_fraction_threshold:
                         check = True
                         break

--- a/test/test_ase_optimizer.py
+++ b/test/test_ase_optimizer.py
@@ -7,6 +7,7 @@ from rdkit.Chem import AllChem
 
 from racerts.optimizer import ASEOptimizer, optimizers
 from racerts.optimizer.ase import (
+    infer_charge_and_multiplicity,
     rdkit_conformer_to_ase_atoms,
     write_ase_positions_to_rdkit,
 )
@@ -163,3 +164,127 @@ def test_ase_optimizer_constructor_validation():
 def test_optimizer_registry_includes_ase():
     assert "ase" in optimizers
     assert optimizers["ase"] is ASEOptimizer
+
+
+def test_neutral_singlet_charge_and_multiplicity_on_atoms():
+    mol = _build_test_mol(num_confs=1)
+    conf_id = mol.GetConformer().GetId()
+    atoms = rdkit_conformer_to_ase_atoms(mol, conf_id=conf_id)
+
+    assert atoms.info["charge"] == 0
+    assert atoms.info["spin"] == 1
+    assert atoms.info["multiplicity"] == 1
+
+
+def test_charged_radical_charge_and_multiplicity_on_atoms():
+    # Methylammonium radical cation: +1 formal charge, one radical electron -> doublet.
+    mol = Chem.AddHs(Chem.MolFromSmiles("[CH2][NH3+]"))
+    AllChem.EmbedMolecule(mol, randomSeed=12)
+
+    inferred = infer_charge_and_multiplicity(mol)
+    assert inferred == {"charge": 1, "multiplicity": 2}
+
+    atoms = rdkit_conformer_to_ase_atoms(mol, conf_id=mol.GetConformer().GetId())
+    assert atoms.info["charge"] == 1
+    assert atoms.info["spin"] == 2
+    assert atoms.info["multiplicity"] == 2
+
+
+def test_charge_and_multiplicity_overrides():
+    mol = _build_test_mol(num_confs=1)
+    atoms = rdkit_conformer_to_ase_atoms(
+        mol, conf_id=mol.GetConformer().GetId(), charge=-1, multiplicity=3
+    )
+    assert atoms.info["charge"] == -1
+    assert atoms.info["spin"] == 3
+    assert atoms.info["multiplicity"] == 3
+
+
+def test_ase_optimizer_num_workers_sets_energies():
+    mol = _build_test_mol(num_confs=4)
+    reference = _reference_from_conf(mol, conf_id=0)
+
+    # Use the calculator class as a (picklable) factory so the spawn pool can build a
+    # fresh calculator per worker.
+    optimizer = ASEOptimizer(
+        calculator=LennardJones,
+        num_workers=2,
+        fmax=0.1,
+        max_steps=10,
+    )
+    optimizer.tune_ts_conformers(mol=mol, reference=reference, align_indices=[0, 1])
+
+    for conf in mol.GetConformers():
+        assert conf.HasProp("energy")
+        assert np.isfinite(conf.GetDoubleProp("energy"))
+
+
+def test_ase_optimizer_num_workers_none_uses_all_cores():
+    # num_workers=None means "auto-size to all available cores" (the relax_conformers
+    # convention); it must take the process path and produce finite energies.
+    mol = _build_test_mol(num_confs=4)
+    reference = _reference_from_conf(mol, conf_id=0)
+
+    optimizer = ASEOptimizer(
+        calculator=LennardJones,
+        num_workers=None,
+        fmax=0.1,
+        max_steps=10,
+    )
+    assert optimizer._use_processes() is True
+    optimizer.tune_ts_conformers(mol=mol, reference=reference, align_indices=[0, 1])
+
+    for conf in mol.GetConformers():
+        assert conf.HasProp("energy")
+        assert np.isfinite(conf.GetDoubleProp("energy"))
+
+
+def test_ase_optimizer_num_workers_keeps_align_indices_fixed():
+    mol = _build_test_mol(num_confs=4)
+    reference = _reference_from_conf(mol, conf_id=0)
+    align_indices = [0, 1]
+
+    optimizer = ASEOptimizer(
+        calculator=LennardJones,
+        num_workers=2,
+        fmax=0.1,
+        max_steps=10,
+    )
+    optimizer.tune_ts_conformers(
+        mol=mol, reference=reference, align_indices=align_indices
+    )
+
+    reference_positions = reference.GetConformer().GetPositions()
+    for conf in mol.GetConformers():
+        positions = conf.GetPositions()
+        assert np.allclose(
+            positions[align_indices],
+            reference_positions[align_indices],
+            atol=1e-2,
+        )
+
+
+def test_ase_optimizer_num_workers_matches_serial():
+    reference = _reference_from_conf(_build_test_mol(num_confs=1), conf_id=0)
+
+    serial_mol = _build_test_mol(num_confs=4)
+    parallel_mol = Chem.Mol(serial_mol)
+
+    serial = ASEOptimizer(
+        calculator=LennardJones(), num_workers=1, fmax=0.1, max_steps=10
+    )
+    serial.tune_ts_conformers(mol=serial_mol, reference=reference, align_indices=[0, 1])
+
+    parallel = ASEOptimizer(
+        calculator=LennardJones, num_workers=2, fmax=0.1, max_steps=10
+    )
+    parallel.tune_ts_conformers(
+        mol=parallel_mol, reference=reference, align_indices=[0, 1]
+    )
+
+    for serial_conf, parallel_conf in zip(
+        serial_mol.GetConformers(), parallel_mol.GetConformers()
+    ):
+        assert np.allclose(
+            serial_conf.GetPositions(), parallel_conf.GetPositions(), atol=1e-3
+        )

--- a/test/test_ase_optimizer.py
+++ b/test/test_ase_optimizer.py
@@ -59,7 +59,7 @@ def test_ase_optimizer_with_calculator_instance_sets_energies():
 
     optimizer = ASEOptimizer(
         calculator=LennardJones(),
-        num_threads=1,
+        num_workers=1,
         fmax=0.1,
         max_steps=10,
     )
@@ -76,7 +76,7 @@ def test_ase_optimizer_with_calculator_class_sets_energies():
 
     optimizer = ASEOptimizer(
         calculator=LennardJones,
-        num_threads=1,
+        num_workers=1,
         fmax=0.1,
         max_steps=10,
     )
@@ -93,7 +93,7 @@ def test_ase_optimizer_with_calculator_callable_sets_energies():
 
     optimizer = ASEOptimizer(
         calculator=lambda: LennardJones(),
-        num_threads=2,
+        num_workers=1,
         fmax=0.1,
         max_steps=10,
     )
@@ -111,7 +111,7 @@ def test_ase_optimizer_keeps_align_indices_fixed():
 
     optimizer = ASEOptimizer(
         calculator=LennardJones(),
-        num_threads=1,
+        num_workers=1,
         fmax=0.1,
         max_steps=10,
     )
@@ -138,7 +138,7 @@ def test_ase_optimizer_external_align_and_optimize():
     reference = _reference_from_conf(mol, conf_id=0)
     optimizer = ASEOptimizer(
         calculator=LennardJones(),
-        num_threads=1,
+        num_workers=1,
         fmax=0.1,
         max_steps=10,
     )
@@ -219,9 +219,8 @@ def test_ase_optimizer_num_workers_sets_energies():
         assert np.isfinite(conf.GetDoubleProp("energy"))
 
 
-def test_ase_optimizer_num_workers_none_uses_all_cores():
-    # num_workers=None means "auto-size to all available cores" (the relax_conformers
-    # convention); it must take the process path and produce finite energies.
+def test_ase_optimizer_num_workers_none_sets_energies():
+    # num_workers=None enables automatic worker selection.
     mol = _build_test_mol(num_confs=4)
     reference = _reference_from_conf(mol, conf_id=0)
 
@@ -231,7 +230,6 @@ def test_ase_optimizer_num_workers_none_uses_all_cores():
         fmax=0.1,
         max_steps=10,
     )
-    assert optimizer._use_processes() is True
     optimizer.tune_ts_conformers(mol=mol, reference=reference, align_indices=[0, 1])
 
     for conf in mol.GetConformers():

--- a/test/test_pruner.py
+++ b/test/test_pruner.py
@@ -1,0 +1,28 @@
+import pytest
+from rdkit import Chem
+from rdkit.Geometry import Point3D
+
+from racerts.pruner import RMSDPruner
+
+
+@pytest.mark.parametrize(
+    ("smiles", "positions"),
+    [
+        ("[Br-]", [(0.0, 0.0, 0.0)]),
+        (
+            "O=C=O",
+            [(-1.0, 0.0, 0.0), (0.0, 0.0, 0.0), (1.0, 0.0, 0.0)],
+        ),
+    ],
+)
+def test_rmsd_pruner_handles_zero_principal_moments(smiles, positions):
+    mol = Chem.MolFromSmiles(smiles)
+    for shift in (0.0, 2.0):
+        conformer = Chem.Conformer(mol.GetNumAtoms())
+        for atom_index, (x, y, z) in enumerate(positions):
+            conformer.SetAtomPosition(atom_index, Point3D(x + shift, y, z))
+        mol.AddConformer(conformer, assignId=True)
+
+    RMSDPruner().prune(mol)
+
+    assert mol.GetNumConformers() == 1


### PR DESCRIPTION
Two improvements:
1. Switched to process based parallelism for conformer optimisation. In general, many ase calculators are not thread safe. Examples: gfnff ase calculator, TBLite ase calculators.
2. Fixed a bug in RMSD prunning of single atom species, causing the crash.